### PR TITLE
Added fuzzing and Mayhem integration for tendril

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,93 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: tendril
+  POP_BACK_MAYHEMFILE: Mayhem/pop_back.mayhemfile
+  POP_FRONT_MAYHEMFILE: Mayhem/pop_front.mayhemfile
+  STRING_BYTES_EQ_TENDRIL_MAYHEMFILE: Mayhem/string_bytes_eq_tendril.mayhemfile
+  SUBTENDRIL_MAYHEMFILE: Mayhem/subtendril.mayhemfile
+  TRY_PUSH_CHAR_MAYHEMFILE: Mayhem/try_push_char.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis for pop_back
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.POP_BACK_MAYHEMFILE }}
+          sarif-output: sarif
+      
+      - name: Start analysis for pop_front
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.POP_FRONT_MAYHEMFILE }}
+          sarif-output: sarif
+      
+      - name: Start analysis for string_bytes_eq_tendril
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.STRING_BYTES_EQ_TENDRIL_MAYHEMFILE }}
+          sarif-output: sarif
+      
+      - name: Start analysis for subtendril
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.SUBTENDRIL_MAYHEMFILE }}
+          sarif-output: sarif
+      
+      - name: Start analysis for try_push_char
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.TRY_PUSH_CHAR_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,23 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /tendril
+WORKDIR /tendril
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /tendril/fuzz
+RUN cargo +nightly fuzz build pop_back && \
+    cargo +nightly fuzz build pop_front && \
+    cargo +nightly fuzz build string_bytes_eq_tendril && \
+    cargo +nightly fuzz build subtendril && \
+    cargo +nightly fuzz build try_push_char
+# Output binaries are placed in /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/pop_back /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/pop_front /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/string_bytes_eq_tendril /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/subtendril /tendril/fuzz/target/x86_64-unknown-linux-gnu/release/try_push_char /

--- a/Mayhem/pop_back.mayhemfile
+++ b/Mayhem/pop_back.mayhemfile
@@ -1,0 +1,5 @@
+project: tendril
+target: pop_back
+
+cmds:
+  - cmd: /pop_back

--- a/Mayhem/pop_front.mayhemfile
+++ b/Mayhem/pop_front.mayhemfile
@@ -1,0 +1,5 @@
+project: tendril
+target: pop_front
+
+cmds:
+  - cmd: /pop_front

--- a/Mayhem/string_bytes_eq_tendril.mayhemfile
+++ b/Mayhem/string_bytes_eq_tendril.mayhemfile
@@ -1,0 +1,5 @@
+project: tendril
+target: string_bytes_eq_tendril
+
+cmds:
+  - cmd: /string_bytes_eq_tendril

--- a/Mayhem/subtendril.mayhemfile
+++ b/Mayhem/subtendril.mayhemfile
@@ -1,0 +1,5 @@
+project: tendril
+target: subtendril
+
+cmds:
+  - cmd: /subtendril

--- a/Mayhem/try_push_char.mayhemfile
+++ b/Mayhem/try_push_char.mayhemfile
@@ -1,0 +1,5 @@
+project: tendril
+target: try_push_char
+
+cmds:
+  - cmd: /try_push_char

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,41 @@
+
+[package]
+name = "tendril-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.tendril]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies]
+rand = "0.4"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "string_bytes_eq_tendril"
+path = "fuzz_targets/string_bytes_eq_tendril.rs"
+
+[[bin]]
+name = "pop_front"
+path = "fuzz_targets/pop_front.rs"
+
+[[bin]]
+name = "pop_back"
+path = "fuzz_targets/pop_back.rs"
+
+[[bin]]
+name = "subtendril"
+path = "fuzz_targets/subtendril.rs"
+
+[[bin]]
+name = "try_push_char"
+path = "fuzz_targets/try_push_char.rs"

--- a/fuzz/fuzz_targets/pop_back.rs
+++ b/fuzz/fuzz_targets/pop_back.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test pop_front
+    let mut rng = rand::thread_rng();
+    let new_len = random_boundary(&mut rng, &buf_string);
+    let n = buf_string.len() - new_len;
+    buf_string.truncate(new_len);
+    buf_tendril.pop_back(n as u32);
+    assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});
+
+fn random_boundary<R: Rng>(rng: &mut R, text: &str) -> usize {
+    loop {
+        let i = Range::new(0, text.len() + 1).ind_sample(rng);
+        if text.is_char_boundary(i) {
+            return i;
+        }
+    }
+}

--- a/fuzz/fuzz_targets/pop_front.rs
+++ b/fuzz/fuzz_targets/pop_front.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use] extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test pop_front
+    let mut rng = rand::thread_rng();
+    let n = random_boundary(&mut rng, &buf_string);
+    buf_tendril.pop_front(n as u32);
+    buf_string = buf_string[n..].to_owned();
+    assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});
+
+fn random_boundary<R: Rng>(rng: &mut R, text: &str) -> usize {
+    loop {
+        let i = Range::new(0, text.len()+1).ind_sample(rng);
+        if text.is_char_boundary(i) {
+            return i;
+        }
+    }
+}

--- a/fuzz/fuzz_targets/string_bytes_eq_tendril.rs
+++ b/fuzz/fuzz_targets/string_bytes_eq_tendril.rs
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+use tendril::StrTendril;
+use std::convert::TryInto;
+
+fuzz_target!(|data: &[u8]| {
+    let capacity = data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+        buf_string.push_str(&str);
+        buf_tendril.push_slice(&str);
+        assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});

--- a/fuzz/fuzz_targets/subtendril.rs
+++ b/fuzz/fuzz_targets/subtendril.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test subtendril
+    let mut rng = rand::thread_rng();
+    let (start, end) = random_slice(&mut rng, &buf_string);
+    buf_string = buf_string[start..end].to_owned();
+    buf_tendril = buf_tendril.subtendril(start as u32, (end - start) as u32);
+    assert_eq!(&*buf_string, &*buf_tendril);
+
+  }
+});
+
+fn random_slice<R: Rng>(rng: &mut R, text: &str) -> (usize, usize) {
+    loop {
+        let start = Range::new(0, text.len() + 1).ind_sample(rng);
+        let end = Range::new(start, text.len() + 1).ind_sample(rng);
+        if !text.is_char_boundary(start) {
+            continue;
+        }
+        if end < text.len() && !text.is_char_boundary(end) {
+            continue;
+        }
+        return (start, end);
+    }
+}

--- a/fuzz/fuzz_targets/try_push_char.rs
+++ b/fuzz/fuzz_targets/try_push_char.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test try_push_char
+    let mut rng = rand::thread_rng();
+    let c = rng.gen();
+    buf_string.push(c);
+    assert!(buf_tendril.try_push_char(c).is_ok());
+    assert_eq!(&*buf_string, &*buf_tendril);
+  }
+});


### PR DESCRIPTION
Added fuzzing and Mayhem integration for `tendril`. The fuzzing tests added were made by user mozfreddyb, and were pulled from their fork of the project. This user had tried to add fuzzing to the project in the past, but the pull request was long-inactive; I simply added their fuzzing tests to allow integration with Mayhem. These tests may potentially be out-of-date, as the last update to the fuzzing tests was in mid-2019.

Mayhem integration was straightforward, as all fuzzing tests are Libfuzzer binaries. A `Dockerfile` was added to create the package, Mayhemfiles were added for each of the 5 fuzzing tests, and a YAML file was added for the Mayhem GitHub action.